### PR TITLE
fix(monitoring): remove duplicate Namespace from sub-kustomizations

### DIFF
--- a/fluxcd/apps/main/monitoring/alertmanager-discord/kustomization.yaml
+++ b/fluxcd/apps/main/monitoring/alertmanager-discord/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 namespace: monitoring
 
 resources:
-  - ../namespace.yaml
   - external-secret.yaml
   - deployment.yaml
   - service.yaml

--- a/fluxcd/apps/main/monitoring/alloy/kustomization.yaml
+++ b/fluxcd/apps/main/monitoring/alloy/kustomization.yaml
@@ -4,6 +4,5 @@ kind: Kustomization
 namespace: monitoring
 
 resources:
-  - ../namespace.yaml
   - ./helm-install.yaml
   - ./networkpolicies.yaml

--- a/fluxcd/apps/main/monitoring/kube-prometheus-stack/kustomization.yaml
+++ b/fluxcd/apps/main/monitoring/kube-prometheus-stack/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 namespace: monitoring
 
 resources:
-  - ../namespace.yaml
   - ./alertmanager-external-secret.yaml
   - ./helm-install.yaml
   - ./ingressroutes.yaml

--- a/fluxcd/apps/main/monitoring/loki/kustomization.yaml
+++ b/fluxcd/apps/main/monitoring/loki/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 namespace: monitoring
 
 resources:
-  - ../namespace.yaml
   - ./external-secret-s3.yaml
   - ./helm-install.yaml
   - ./networkpolicies.yaml


### PR DESCRIPTION
## Summary
- Remove `../namespace.yaml` from nested kustomizations under `monitoring` to avoid duplicate `Namespace/monitoring`.
- Fixes Flux error in `flux-system/apps` Kustomization: `may not add resource with an already registered id: Namespace.v1/monitoring`.

## Test plan
- After merge, run: `flux reconcile kustomization apps -n flux-system`.
- Expect Kustomize to build cleanly and apply monitoring stack.

## Notes
- Will use the flux-operator MCP to coordinate reconciliation and verify status in the current cluster post-merge.